### PR TITLE
fix: move temporary path to data directory

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,6 +89,7 @@ jobs:
         run: |
           echo "ENV=dev" >> .env
           echo "UID=$(id --user)" >> .env
+          echo "DATABASE_DIR=${{ runner.temp }}/document-merge-service/data" >> .env
           echo "MEDIA_ROOT=${{ runner.temp }}/document-merge-service/media" >> .env
       - name: Run tests
         run: poetry run pytest --no-cov-on-fail --cov --create-db -vv

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG UID=901
 
 RUN wget -q https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh -P /usr/local/bin \
   && chmod +x /usr/local/bin/wait-for-it.sh \
-  && mkdir -p /app /var/lib/document-merge-service/data /var/lib/document-merge-service/media /var/www/static \
+  && mkdir -p /app /var/lib/document-merge-service/data/tmp /var/lib/document-merge-service/media /var/www/static \
   && useradd -u $UID -r document-merge-service --create-home \
   && mkdir /home/document-merge-service/.config \
   && chmod -R 770 /var/lib/document-merge-service/data /var/lib/document-merge-service/media /var/www/static /home/document-merge-service \

--- a/document_merge_service/api/views.py
+++ b/document_merge_service/api/views.py
@@ -67,7 +67,7 @@ class TemplateView(viewsets.ModelViewSet):
         convert = serializer.data.get("convert")
 
         if convert:
-            dir = Path(settings.MEDIA_ROOT, "__convert__")
+            dir = Path(settings.DATABASE_DIR, "tmp")
             dir.mkdir(parents=True, exist_ok=True)
             with NamedTemporaryFile("wb", dir=dir) as tmp:
                 tmp.write(response.content)

--- a/document_merge_service/settings.py
+++ b/document_merge_service/settings.py
@@ -29,12 +29,11 @@ ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=default(["*"]))
 # Database
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 
+DATABASE_DIR = env.str("DATABASE_DIR", default="/var/lib/document-merge-service/data")
 DATABASES = {
     "default": {
         "ENGINE": env.str("DATABASE_ENGINE", default="django.db.backends.sqlite3"),
-        "NAME": env.str(
-            "DATABASE_NAME", default="/var/lib/document-merge-service/data/sqlite3.db"
-        ),
+        "NAME": env.str("DATABASE_NAME", default=f"{DATABASE_DIR}/sqlite3.db"),
         "USER": env.str("DATABASE_USER", default=""),
         "PASSWORD": env.str("DATABASE_PASSWORD", default=""),
         "HOST": env.str("DATABASE_HOST", default=""),


### PR DESCRIPTION
Since we hide /tmp from LibreOffice processes we can't use /tmp for temporary files. I first used `$MEDIA_ROOT/__convert__`, but this directory is not an internal directory as I expected (it was a bad idea), so I moved `__convert__` to /var/lib/document_merge_service/data/tmp ($DATABASE_DIR/tmp). The Dockerfile will set the rights correctly: shared between the dms-user and root.