### PR TITLE
feat(api): make pagination configurable

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -71,3 +71,8 @@ supporting Open ID Connect. If not available, you might consider using
 * `CORS_ORIGIN_REGEX_WHITELIST`: List of [whitelist regexes](https://github.com/ottoyiu/django-cors-headers#cors_origin_regex_whitelist) defaults to "^(https?://)?127\.0\.0\.1:\d{4}$"
 
 Users of nginx/apache must ensure to have matching CORS configurations.
+
+## Pagination
+* `PAGINATION_ENABLED`: whether the pagination is enabled (default: `True`)
+* `PAGINATION_DEFAULT_PAGE_SIZE`: the default page size if no query param (`page_size`) is given (default: `100`)
+* `PAGINATION_MAX_PAGE_SIZE`: the max value of the page size query param (`page_size`) (default: `1000`)

--- a/document_merge_service/api/pagination.py
+++ b/document_merge_service/api/pagination.py
@@ -1,0 +1,7 @@
+from django.conf import settings
+from rest_framework.pagination import PageNumberPagination
+
+
+class APIPagination(PageNumberPagination):
+    page_size_query_param = "page_size"
+    max_page_size = settings.PAGINATION_MAX_PAGE_SIZE

--- a/document_merge_service/api/tests/test_pagination.py
+++ b/document_merge_service/api/tests/test_pagination.py
@@ -1,0 +1,26 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+
+@pytest.mark.parametrize(
+    "query_params,expected",
+    [
+        ({"page_size": 10}, 10),
+        ({"page_size": 120}, 110),  # max page size reached
+        ({}, 100),  # default page size
+    ],
+)
+def test_pagination(db, client, template_factory, query_params, expected, mocker):
+    mocker.patch(
+        "document_merge_service.api.pagination.APIPagination.max_page_size", 110
+    )
+
+    template_factory.create_batch(120)
+
+    response = client.get(reverse("template-list"), data=query_params)
+
+    assert response.status_code == status.HTTP_200_OK
+    result = response.json()
+    assert result["count"] == 120
+    assert len(result["results"]) == expected

--- a/document_merge_service/settings.py
+++ b/document_merge_service/settings.py
@@ -199,8 +199,6 @@ if OIDC_GROUPS_API and not OIDC_GROUPS_API_JSONPATH:  # pragma: no cover
 # https://www.django-rest-framework.org/api-guide/settings/
 
 REST_FRAMEWORK = {
-    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
-    "PAGE_SIZE": 100,
     "DEFAULT_PERMISSION_CLASSES": [
         "document_merge_service.api.permissions.AsConfigured"
     ],
@@ -215,6 +213,18 @@ REST_FRAMEWORK = {
     ),
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
 }
+
+PAGINATION_ENABLED = env.bool("PAGINATION_ENABLED", True)
+PAGINATION_DEFAULT_PAGE_SIZE = env.int("PAGINATION_DEFAULT_PAGE_SIZE", 100)
+PAGINATION_MAX_PAGE_SIZE = env.int("PAGINATION_MAX_PAGE_SIZE", 1000)
+
+if PAGINATION_ENABLED:
+    REST_FRAMEWORK.update(
+        {
+            "DEFAULT_PAGINATION_CLASS": "document_merge_service.api.pagination.APIPagination",
+            "PAGE_SIZE": PAGINATION_DEFAULT_PAGE_SIZE,
+        }
+    )
 
 # Logging
 LOGGING = {


### PR DESCRIPTION
This adds the possiblity to configure the pagination via environment variables and query params:

- Add possibility to let the client configure the page size via the `page_size` query param
- Add env var `PAGINATION_ENABLED` to completely disable pagination
- Add env var `PAGINATION_DEFAULT_PAGE_SIZE` to configure the default page size
- Add env var `PAGINATION_MAX_PAGE_SIZE` to configure the max value of the `page_size` query param