### PR TITLE
fix(dgap): add env variables to configure permissions and visibilities

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -56,6 +56,15 @@ supporting Open ID Connect. If not available, you might consider using
 - `OIDC_GROUPS_CLAIM`: Name of claim to be used to define group membership (default: document_merge_service_groups)
 - `OIDC_BEARER_TOKEN_REVALIDATION_TIME`: Time in seconds before bearer token validity is verified again. For best security token is validated on each request per default. It might be helpful though in case of slow Open ID Connect provider to cache it. It uses [cache](#cache) mechanism for memorizing userinfo result. Number has to be lower than access token expiration time. (default: 0)
 
+## Permissions / Visibilities
+
+Document Merge Service uses [dgap](https://github.com/adfinis/django-generic-api-permissions)
+to handle permissions and visibilities. It can be configured using the following
+environment variables:
+
+- `DMS_VISIBILITY_CLASSES`: List of classes that handle [dgap visibilities](https://github.com/adfinis/django-generic-api-permissions#visibilities)
+- `DMS_PERMISSION_CLASSES`: List of classes that handle [dgap permissions](https://github.com/adfinis/django-generic-api-permissions#permissions)
+
 ## Cache
 
 - `CACHE_BACKEND`: [cache backend](https://docs.djangoproject.com/en/1.11/ref/settings/#backend) to use (default: django.core.cache.backends.locmem.LocMemCache)

--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -14,12 +14,12 @@ Because every consuming app can now define its own way to handle the permissions
 
 Example Permissions:
 
-```py
+```python
 import requests
 from rest_framework import exceptions
 from generic_permissions.permissions import object_permission_for
 
-from document_merge_service.models import Template
+from document_merge_service.api.models import Template
 
 
 class CustomPermission:
@@ -58,19 +58,25 @@ class CustomPermission:
         return instance.meta["group"] in groups
 ```
 
-After creating the permission define it in `settings.py` for dgap.
+After creating the permission configure it as environment variable in your `docker-compose.yml` file:
 
-```py
-GENERIC_PERMISSIONS_PERMISSION_CLASSES = ['app.permissions.CustomPermission']
+```yaml
+services:
+  document-merge-service:
+    image: ghcr.io/adfinis/document-merge-service:latest
+    environment:
+      - DMS_PERMISSION_CLASSES=document_merge_service.extensions.permissions.CustomPermission
+    volumes:
+      - ./permissions.py:/app/document_merge_service/extensions/permissions.py
 ```
 
 Example Visibility:
 
-```py
+```python
 from django.db.models import Q
 from generic_permissions.visibilities import filter_queryset_for
 
-from document_merge_service.models import Template
+from document_merge_service.api.models import Template
 
 
 class CustomVisibility:
@@ -85,8 +91,14 @@ class CustomVisibility:
         return queryset
 ```
 
-After creating the visibility define it in `settings.py` for dgap.
+After creating the visibility configure it as environment variable in your `docker-compose.yml` file:
 
-```py
-GENERIC_PERMISSIONS_VISIBILITY_CLASSES = ['app.visibilites.CustomVisibility']
+```yaml
+services:
+  document-merge-service:
+    image: ghcr.io/adfinis/document-merge-service:latest
+    environment:
+      - DMS_VISIBILITY_CLASSES=document_merge_service.extensions.visibilities.CustomVisibility
+    volumes:
+      - ./visibilities.py:/app/document_merge_service/extensions/visibilities.py
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
     volumes:
       - dbdata:/var/lib/document-merge-service/data
       - templatefiles:/var/lib/document-merge-service/media
+      # Example to include custom extensions
+      # - ./visibilities.py:/app/document_merge_service/extensions/visibilities.py
+      # - ./permissions.py:/app/document_merge_service/extensions/permissions.py
     environment: []
       # Following options are a must to configure on production system:
       # https://docs.djangoproject.com/en/2.1/ref/settings/#std:setting-SECRET_KEY

--- a/document_merge_service/extensions/permissions.py
+++ b/document_merge_service/extensions/permissions.py
@@ -1,0 +1,1 @@
+# To be overwritten for permission extensions point

--- a/document_merge_service/extensions/visibilities.py
+++ b/document_merge_service/extensions/visibilities.py
@@ -1,0 +1,1 @@
+# To be overwritten for validation extensions point

--- a/document_merge_service/settings.py
+++ b/document_merge_service/settings.py
@@ -268,3 +268,7 @@ if SENTRY_DSN:  # pragma: no cover
         SENTRY_TRACES_SAMPLE_RATE,
         SENTRY_SEND_DEFAULT_PII,
     )
+
+# https://github.com/adfinis/django-generic-api-permissions
+GENERIC_PERMISSIONS_PERMISSION_CLASSES = env.list("DMS_PERMISSION_CLASSES", default=[])
+GENERIC_PERMISSIONS_VISIBILITY_CLASSES = env.list("DMS_VISIBILITY_CLASSES", default=[])


### PR DESCRIPTION
Document Merge Service is not supposed to be run as django application inside of a django project but as standalone docker service. Therefore, it must be completely 12factor compatible. To achieve this, we need to have env vars for permission and visibility classes.

CC @Yelinz 