### PR TITLE
fix(template): migrate group to meta property before removing

### DIFF
--- a/document_merge_service/api/migrations/0006_remove_template_group.py
+++ b/document_merge_service/api/migrations/0006_remove_template_group.py
@@ -3,12 +3,30 @@
 from django.db import migrations
 
 
+def migrate_group_to_meta(apps, schema_editor):
+    Template = apps.get_model("api", "Template")
+
+    for template in Template.objects.filter(group__isnull=False):
+        template.meta["group"] = template.group
+        template.save()
+
+
+def migrate_group_to_meta_reverse(apps, schema_editor):
+    Template = apps.get_model("api", "Template")
+
+    for template in Template.objects.filter(meta__has_key="group"):
+        template.group = template.meta["group"]
+        del template.meta["group"]
+        template.save()
+
+
 class Migration(migrations.Migration):
     dependencies = [
         ("api", "0005_xlsx_template_engine"),
     ]
 
     operations = [
+        migrations.RunPython(migrate_group_to_meta, migrate_group_to_meta_reverse),
         migrations.RemoveField(
             model_name="template",
             name="group",


### PR DESCRIPTION
This adjustment in the migration will be too late for projects that already ran the migration. However, IMO it's still worth to adjust it so we don't loose any more data.

As we recommend migrating that info into a meta property, we do exactly that in the migration.