### PR TITLE
feat(api): accept available placeholders as json list

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   document-merge-service:
     image: ghcr.io/adfinis/document-merge-service:dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   document-merge-service:
     image: ghcr.io/adfinis/document-merge-service:latest


### PR DESCRIPTION
Instead of multiple fields with the same name (traditional form-data
lists), we also accept a JSON list for the available placeholders. This
helps reduce the number of fields in the request, which WAF, Django, and
possibly other server-side web components don't appreciate.
