### PR TITLE
Use Ubuntu 22.04 for GitHub actions

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -25,7 +25,7 @@ jobs:
   # Push image to GitHub Packages.
   # See also https://docs.docker.com/build/ci/github-actions/
   container-registry:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       ENV: dev
     steps:
@@ -47,7 +47,7 @@ jobs:
   docker-tests:
     name: Docker tests
     needs: [lint]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       ENV: dev
     steps:
@@ -66,7 +66,7 @@ jobs:
   compatibility-tests:
     name: Compatibility tests
     needs: [lint]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
ubuntu-latest has recently switched to Ubuntu 24.04, with some breaking changes, among others restricting the creation of namespaces as unprivileged user, but also other compatibility issues within Python itself.

Until this is resolved, we pin the runs to Ubuntu 22.04.