### PR TITLE
feat(build): use multi stage docker build for smaller images

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: "3.12"
           cache: "poetry"
       - name: Install dependencies
-        run: poetry install --all-extras
+        run: poetry install --all-extras --with dev
       - name: Run gitlint
         run: poetry run gitlint --contrib contrib-title-conventional-commits
       - name: Run ruff check
@@ -61,7 +61,7 @@ jobs:
       - name: Build docker containers
         run: docker compose up -d --build
       - name: Run pytest
-        run: docker compose exec -T document-merge-service poetry run pytest --no-cov-on-fail --cov --create-db -vv
+        run: docker compose exec -T document-merge-service pytest --no-cov-on-fail --cov --create-db -vv
 
   compatibility-tests:
     name: Compatibility tests
@@ -121,7 +121,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends util-linux unoconv libreoffice-writer libmagic1
-          poetry install --all-extras
+          poetry install --all-extras --with dev
       - name: Set environment
         run: |
           echo "ENV=dev" >> .env

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-dev start test
+.PHONY: help start test shell format dmypy
 .DEFAULT_GOAL := help
 
 help:
@@ -8,13 +8,13 @@ start: ## Start the development server
 	@docker compose up -d --build
 
 test: ## Test the project
-	@docker compose exec document-merge-service poetry run sh -c "ruff format --diff --fix . && ruff check --diff . && mypy document_merge_service && pytest --no-cov-on-fail --cov --create-db"
+	@docker compose exec document-merge-service sh -c "ruff format --diff --fix . && ruff check --diff . && mypy document_merge_service && pytest --no-cov-on-fail --cov --create-db"
 
 shell: ## Shell into document merge service
-	@docker compose exec document-merge-service poetry shell
+	@docker compose exec document-merge-service bash
 
 format: ## Format python code with ruff check
-	@docker compose exec document-merge-service poetry run ruff format --diff .
+	@docker compose exec document-merge-service ruff format --diff .
 
 dmypy: ## Run mypy locally (starts a deamon for performance)
 	dmypy run document_merge_service

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -17,7 +17,7 @@ services:
       [
         "/bin/sh",
         "-c",
-        "poetry run python ./manage.py migrate && poetry run python ./manage.py runserver 0.0.0.0:8000"
+        "./manage.py migrate && ./manage.py runserver 0.0.0.0:8000"
       ]
     environment:
       - ENV=dev

--- a/poetry.lock
+++ b/poetry.lock
@@ -3545,4 +3545,4 @@ s3 = ["boto3"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10.0,<3.14"
-content-hash = "589da8f92a7a84d7637d2fd0082bdbd563ee9af83cef3b57b10d4d7f0fc8834e"
+content-hash = "156cb95316d8d0be88c81d669d9ebbedc27ffe31c7f650cfbdb99d5bb542db82"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ uWSGI = "^2.0.21"
 xltpl = "~0.21"
 poetry = "^2.0.0"
 
+[tool.poetry.group.dev]
+optional = true
+
 [tool.poetry.group.dev.dependencies]
 django-stubs = "5.2.0"
 factory-boy = "3.3.3"


### PR DESCRIPTION
BREAKING CHANGE: This will remove poetry entirely from the production
image. If you customized the command, make sure to remove `poetry run`
as the binaries are now globally available without using poetry.

If you installed additional requirements using `poetry install` make
sure to use `pip install` instead.

---

This reduces the production image size from ~1.5GB to ~800MB