### PR TITLE
chore(deps): update django-storages reference after force-push

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -661,7 +661,7 @@ sftp = ["paramiko (>=1.15)"]
 type = "git"
 url = "https://github.com/adfinis-forks/django-storages"
 reference = "s3-head-object-sse-c"
-resolved_reference = "b6555067f7114f254defbf6bd3002abecb75181f"
+resolved_reference = "76dcb64acf2007b229493a28319d72f7af4f9bfa"
 
 [[package]]
 name = "django-stubs"


### PR DESCRIPTION
Note that the branch containing this commit has been merged into upstream django-storages via https://github.com/jschneier/django-storages/pull/1451 in the meantime, but did not make it into the 1.14.5 release, which happened 3 days prior to the MR being merged.