### PR TITLE
chore(release): v7.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 7.3.6 (8 April 2025)
+
+### Fix
+
+* **deps:** Fix locked dependency on django-storages ([`bf085a9`](https://github.com/adfinis/document-merge-service/commit/bf085a9808bdb76bb70bb8e834b92b6290384c73))
+* **api:** Delete old file when updating template file ([`f98e38b`](https://github.com/adfinis/document-merge-service/commit/f98e38bdb1c1fff84e9e4f3c82d234250cd44c8d))
+
 ## 7.3.5 (13 January 2025)
 
 ### Fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "document-merge-service"
-version = "7.3.5"
+version = "7.3.6"
 description = "Merge Document Template Service"
 license = "GPL-3.0-or-later"
 authors = ["Adfinis AG <info@adfinis.com>"]


### PR DESCRIPTION
Contains #956, #957 (and #933, not mentioned in the changelogs, as it only affects the CI pipeline).