### PR TITLE
fix(ci): create images also on release drafts being published

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -2,7 +2,9 @@ name: Container image
 
 on:
   release:
-    types: [created]
+    types:
+      - created
+      - published
 
   # Run build for any PRs - we won't push in those however
   pull_request:


### PR DESCRIPTION
This addresses the issue of the v7.3.6 release not triggering a container image build.