### PR TITLE
feat(docker): add image variants

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -32,6 +32,14 @@ jobs:
       packages: write
       contents: read
 
+    strategy:
+      matrix:
+        include:
+          - variant: slim
+            suffix: -slim
+          - variant: full
+            suffix:
+
     steps:
       - uses: actions/checkout@v4
 
@@ -52,10 +60,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}
           tags: |
-            type=raw,value=dev,enable={{is_default_branch}}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=raw,value=dev${{ matrix.suffix }},enable={{is_default_branch}}
+            type=semver,pattern={{version}}${{ matrix.suffix }}
+            type=semver,pattern={{major}}.{{minor}}${{ matrix.suffix }}
+            type=semver,pattern={{major}}${{ matrix.suffix }}
           labels: |
             org.opencontainers.image.title=document-merge-service
             org.opencontainers.image.description=${{ github.event.repository.description }}
@@ -74,3 +82,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: VARIANT=${{ matrix.variant }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: "3.12"
           cache: "poetry"
       - name: Install dependencies
-        run: poetry install --all-extras --with dev
+        run: poetry install --with dev
       - name: Run gitlint
         run: poetry run gitlint --contrib contrib-title-conventional-commits
       - name: Run ruff check
@@ -106,7 +106,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends util-linux unoconv libreoffice-writer libmagic1
-          poetry install --all-extras --with dev
+          poetry install --extras full --with dev
       - name: Set environment
         run: |
           echo "ENV=dev" >> .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.13 AS build
 
 ARG ENV=docker
 ARG APP_HOME=/app
+ARG VARIANT=slim
 
 ENV PYTHONUNBUFFERED=1
 ENV POETRY_VIRTUALENVS_CREATE=false
@@ -15,7 +16,7 @@ RUN pip install --no-cache-dir -U poetry
 COPY pyproject.toml poetry.lock $APP_HOME/
 RUN \
   --mount=type=cache,target=.cache/pypoetry \
-  poetry install --no-root --all-extras $(test "$ENV" = "dev" && echo "--with dev")
+  poetry install --no-root --extras $VARIANT $(test "$ENV" = "dev" && echo "--with dev")
 
 # Install project itself
 COPY . $APP_HOME

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -6,6 +6,7 @@ services:
       args:
         - ENV=dev
         - UID=$UID
+        - VARIANT=full
     cap_add:
       - CAP_SYS_ADMIN
     security_opt:

--- a/poetry.lock
+++ b/poetry.lock
@@ -95,7 +95,7 @@ description = "The AWS SDK for Python"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"s3\""
+markers = "extra == \"full\""
 files = [
     {file = "boto3-1.38.17-py3-none-any.whl", hash = "sha256:9b56c98fe7acb6559c24dacd838989878c60f3df2fb8ca5f311128419fd9f953"},
     {file = "boto3-1.38.17.tar.gz", hash = "sha256:6058feef976ece2878ad3555f39933e63d20d02e2bbd40610ab2926d4555710a"},
@@ -116,7 +116,7 @@ description = "Low-level, data-driven core of boto 3."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"s3\""
+markers = "extra == \"full\""
 files = [
     {file = "botocore-1.38.17-py3-none-any.whl", hash = "sha256:ec75cf02fbd3dbec18187085ce387761eab16afdccfd0774fd168db3689c6cb6"},
     {file = "botocore-1.38.17.tar.gz", hash = "sha256:f2db4c4bdcfbc41d78bfe73b9affe7d217c7840f8ce120cff815536969418b18"},
@@ -1377,7 +1377,7 @@ description = "JSON Matching Expressions"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "extra == \"s3\""
+markers = "extra == \"full\""
 files = [
     {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
     {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
@@ -2113,7 +2113,7 @@ description = "PostgreSQL database adapter for Python"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"pgsql\""
+markers = "extra == \"full\""
 files = [
     {file = "psycopg-3.2.9-py3-none-any.whl", hash = "sha256:01a8dadccdaac2123c916208c96e06631641c0566b22005493f09663c7a8d3b6"},
     {file = "psycopg-3.2.9.tar.gz", hash = "sha256:2fbb46fcd17bc81f993f28c47f1ebea38d66ae97cc2dbc3cad73b37cefbff700"},
@@ -2139,7 +2139,7 @@ description = "PostgreSQL database adapter for Python -- C optimisation distribu
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"pgsql\" and implementation_name != \"pypy\""
+markers = "extra == \"full\" and implementation_name != \"pypy\""
 files = [
     {file = "psycopg_binary-3.2.9-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:528239bbf55728ba0eacbd20632342867590273a9bacedac7538ebff890f1093"},
     {file = "psycopg_binary-3.2.9-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e4978c01ca4c208c9d6376bd585e2c0771986b76ff7ea518f6d2b51faece75e8"},
@@ -2243,7 +2243,7 @@ description = "A comprehensive, fast, pure Python memcached client"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "extra == \"memcache\""
+markers = "extra == \"full\""
 files = [
     {file = "pymemcache-4.0.0-py2.py3-none-any.whl", hash = "sha256:f507bc20e0dc8d562f8df9d872107a278df049fa496805c1431b926f3ddd0eab"},
     {file = "pymemcache-4.0.0.tar.gz", hash = "sha256:27bf9bd1bbc1e20f83633208620d56de50f14185055e49504f4f5e94e94aff94"},
@@ -2778,7 +2778,7 @@ description = "An Amazon S3 Transfer Manager"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"s3\""
+markers = "extra == \"full\""
 files = [
     {file = "s3transfer-0.12.0-py3-none-any.whl", hash = "sha256:35b314d7d82865756edab59f7baebc6b477189e6ab4c53050e28c1de4d9cce18"},
     {file = "s3transfer-0.12.0.tar.gz", hash = "sha256:8ac58bc1989a3fdb7c7f3ee0918a66b160d038a147c7b5db1500930a607e9a1c"},
@@ -3542,11 +3542,10 @@ cffi = {version = ">=1.11", markers = "platform_python_implementation == \"PyPy\
 cffi = ["cffi (>=1.11)"]
 
 [extras]
-memcache = ["pymemcache"]
-pgsql = ["psycopg"]
-s3 = ["boto3"]
+full = ["boto3", "psycopg", "pymemcache"]
+slim = []
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10.0,<3.14"
-content-hash = "4af881ee1f52da610b4942c4053ac24f2c10e0d6d4e3c8a69ca7e8d94b175994"
+content-hash = "eea93175e4d9a564fa1236192b8dbe3a79bdf8cbf6426ab27b5c34b476e2d67a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,9 +77,8 @@ types-setuptools = "80.7.0.20250516"
 types-toml = "0.10.8.20240310"
 
 [tool.poetry.extras]
-pgsql = ["psycopg"]
-memcache = ["pymemcache"]
-s3 = ["boto3"]
+full = ["psycopg", "pymemcache", "boto3"]
+slim = []
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
This introduces a `slim` image variant that does not have any extras (PostgreSQL, Memcached, S3) installed. This image can be used in very simple setups or in setups that require other dependencies (e.g. MySQL or Azure Storage).

Resolves #572

---

**Approximal image sizes:**

Full: 813MB
Slim: 780MB
