### PR TITLE
feat(security): add censored exception report filter

### DIFF
--- a/document_merge_service/api/logging.py
+++ b/document_merge_service/api/logging.py
@@ -1,0 +1,36 @@
+import re
+
+from django.views.debug import SafeExceptionReporterFilter
+
+
+class CensoredExceptionReporterFilter(SafeExceptionReporterFilter):
+    """Very conservative exception reporter filter.
+
+    This exception reporter filter should be used in production environments to
+    avoid sending sensitive data in email exceptions. This will remove any
+    settings from the exception body and also censors alot of request
+    information (e.g the auth token).
+    """
+
+    hidden_settings = re.compile(
+        # Exclude HTTP_AUTHORIZATION from logs
+        "API|AUTH|TOKEN|KEY|SECRET|PASS|SIGNATURE|HTTP_COOKIE|HTTP_AUTHORIZATION",
+        flags=re.IGNORECASE,
+    )
+
+    def get_post_parameters(self, request):
+        """Don't log any post parameters."""
+
+        return {}
+
+    def get_safe_request_meta(self, request):
+        """Only log HTTP_* values from `request.META`."""
+
+        meta = super().get_safe_request_meta(request)
+
+        return {k: v for k, v in meta.items() if k.startswith("HTTP_")}
+
+    def get_safe_settings(self):
+        """Don't log any settings."""
+
+        return {}

--- a/document_merge_service/api/tests/__snapshots__/test_email_logging.ambr
+++ b/document_merge_service/api/tests/__snapshots__/test_email_logging.ambr
@@ -1,0 +1,23 @@
+# serializer version: 1
+# name: test_error_email
+  '''
+  USER: [unable to retrieve the current user]
+  
+  GET: No GET data
+  
+  POST: No POST data
+  
+  FILES: No FILES data
+  
+  COOKIES: No cookie data
+  
+  META:
+  HTTP_AUTHORIZATION = '********************'
+  HTTP_COOKIE = '********************'
+  HTTP_USER_AGENT = 'pytest'
+  HTTP_X_CAMAC_GROUP = '123'
+  
+  Settings:
+  Using settings module
+  '''
+# ---

--- a/document_merge_service/api/tests/test_email_logging.py
+++ b/document_merge_service/api/tests/test_email_logging.py
@@ -1,0 +1,65 @@
+import logging.config
+
+import pytest
+from django.test import Client
+from django.urls import path
+from django.views.debug import get_default_exception_reporter_filter
+from rest_framework import status
+
+
+def exception_view(request):
+    raise Exception("This is an exception to test error emails")
+
+
+urlpatterns = [path("exception-test/", exception_view)]
+
+
+@pytest.mark.django_db
+def test_error_email(mailoutbox, settings, snapshot):
+    settings.ROOT_URLCONF = __name__
+    settings.DEBUG = False
+    settings.ADMINS = [("Admin Test", "admin@example.com")]
+    settings.ENABLE_ADMIN_EMAIL_LOGGING = True
+    settings.DEFAULT_EXCEPTION_REPORTER_FILTER = (
+        "document_merge_service.api.logging.CensoredExceptionReporterFilter"
+    )
+    settings.LOGGING = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "handlers": {
+            "mail_admins": {
+                "level": "ERROR",
+                "class": "django.utils.log.AdminEmailHandler",
+            },
+        },
+        "loggers": {
+            "django.request": {
+                "handlers": ["mail_admins"],
+                "level": "ERROR",
+                "propagate": True,
+            },
+        },
+    }
+    logging.config.dictConfig(settings.LOGGING)
+
+    # Make sure lru cache of the function that uses the above setting is empty
+    get_default_exception_reporter_filter.cache_clear()
+    assert get_default_exception_reporter_filter.cache_info().hits == 0
+
+    client = Client()
+    client.raise_request_exception = False
+
+    response = client.post(
+        "/exception-test/",
+        data={"foo": "bar"},
+        HTTP_USER_AGENT="pytest",
+        HTTP_AUTHORIZATION="Bearer sometoken",
+        HTTP_X_CAMAC_GROUP="123",
+    )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert len(mailoutbox) == 1
+
+    # Only check everything after "Request information" as the header data and
+    # traceback would cause this snapshot to be failing all the time
+    assert snapshot == mailoutbox[0].body.split("Request information:", 1)[-1].strip()

--- a/document_merge_service/settings.py
+++ b/document_merge_service/settings.py
@@ -284,6 +284,11 @@ LOGGING = {
     "loggers": {"django": {"handlers": ["console"], "level": "WARNING"}},
 }
 
+DEFAULT_EXCEPTION_REPORTER_FILTER = env.str(
+    "DEFAULT_EXCEPTION_REPORTER_FILTER",
+    "document_merge_service.api.logging.CensoredExceptionReporterFilter",
+)
+
 URL_PREFIX = env.str("URL_PREFIX", default="")
 
 # Email settings


### PR DESCRIPTION
Users of the app can also override this by settting `DEFAULT_EXCEPTION_REPORTER_FILTER` to a custom subclass of `SafeExceptionReportFilter`.

https://docs.djangoproject.com/en/6.0/howto/error-reporting/#django.views.debug.SafeExceptionReporterFilter
