### PR TITLE
fix(api): handle non-existent data in storage for changing files

### DIFF
--- a/document_merge_service/api/models.py
+++ b/document_merge_service/api/models.py
@@ -64,12 +64,14 @@ def auto_delete_file_on_change(sender, instance, **kwargs):
     only other, normal attributes are changed), we keep the file.
     """
 
-    try:
-        old_file = Template.objects.get(pk=instance.pk).template
-    except Template.DoesNotExist:
+    # Check if new file is being uploaded:
+    new_template = instance.template
+    if not new_template or not isinstance(new_template.file, UploadedFile):
         return
 
-    if old_file:
-        new_file = instance.template
-        if isinstance(new_file.file, UploadedFile):
+    # New file is being uploaded, delete old file if there's any:
+    try:
+        if old_file := Template.objects.get(pk=instance.pk).template:
             DefaultStorage().delete(old_file.name)
+    except Template.DoesNotExist:
+        pass

--- a/document_merge_service/api/models.py
+++ b/document_merge_service/api/models.py
@@ -55,7 +55,7 @@ def auto_delete_file_on_delete(sender, instance, **kwargs):
 
 
 @receiver(models.signals.pre_save, sender=Template)
-def auto_delete_file_on_change(sender, instance, **kwargs):
+def auto_delete_file_on_change(sender, instance, raw, **kwargs):
     """
     Delete old template file from filesystem when `Template` is given a new template file.
 
@@ -65,9 +65,17 @@ def auto_delete_file_on_change(sender, instance, **kwargs):
     """
 
     # Check if new file is being uploaded:
-    new_template = instance.template
-    if not new_template or not isinstance(new_template.file, UploadedFile):
-        return
+    try:
+        new_template = instance.template
+        if not new_template or not isinstance(new_template.file, UploadedFile):
+            return
+    except FileNotFoundError as e:
+        # For raw additions (e.g. loading fixtures), we cannot guarantee that the
+        # corresponding file is present in the storage, so we ignore this error.
+        # For non-raw additions (i.e. regular uploads), this is an error that should be
+        # handled further up.
+        if not raw:
+            raise e
 
     # New file is being uploaded, delete old file if there's any:
     try:


### PR DESCRIPTION
Loading fixture data from a dump (`loaddata`) causes file entries to be added without actually adding the corresponding file to the storage.

But `auto_delete_file_on_change` is triggered anyway, and we try to inspect the added file (which then fails if the file isn't already in the storage for some reason).

To prevent loaddata from failing, we now catch any `FileNotFoundError` raised in the inspection of the new file ~~(and also do not delete any files from the storage, to play it safe)~~ *(amended in a later revision)*.