### PR TITLE
chore(doc): v9.2.3 release entry in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 9.2.3 (27 May 2026)
+
+### Fix
+
+* **api:** Ignore missing storage objects for raw additions ([`c640d9a`](https://github.com/adfinis/document-merge-service/commit/c640d9aa6410614be713f1a1988a9cf502abd701))
+
 ## 9.2.2 (12 May 2026)
 
 ### Fix


### PR DESCRIPTION
Ported from 5fc3a0bd92a9ab318a443fa278c6a2b2c9ec12cd on the v9.2 branch (#1167).