### PR TITLE
fix(xlsx): remove dir and getattr globals

### DIFF
--- a/document_merge_service/api/engines.py
+++ b/document_merge_service/api/engines.py
@@ -264,7 +264,6 @@ class XlsxTemplateEngine:
         writer.jinja_env.filters.update(get_jinja_filters())
         if is_test_merge:
             writer.jinja_env.undefined = self._undefined_factory
-        writer.jinja_env.globals.update(dir=dir, getattr=getattr)
 
         payloads = []
         sheets = writer.sheet_resource_map.sheet_state_list


### PR DESCRIPTION
The override is not necessary and imposes security risks, as it's dissolving the jinja sandbox barriers.

Introducing commit: https://github.com/adfinis/document-merge-service/commit/e133c834128916eb26ff7642e6eb31852406743c